### PR TITLE
ApiHandler 구현하기

### DIFF
--- a/app/src/main/java/com/mimo/android/data/model/request/UserRequest.kt
+++ b/app/src/main/java/com/mimo/android/data/model/request/UserRequest.kt
@@ -2,7 +2,7 @@ package com.mimo.android.data.model.request
 
 data class UserRequest(
     val userName: String = "",
-    val userContact: String = "",
+    val userContact: String? = null,
     val accessToken: String = "",
     val refreshToken: String = "",
 )

--- a/app/src/main/java/com/mimo/android/data/model/response/ApiResponse.kt
+++ b/app/src/main/java/com/mimo/android/data/model/response/ApiResponse.kt
@@ -1,6 +1,6 @@
 package com.mimo.android.data.model.response
 
-import com.mimo.android.util.ErrorCode
+import retrofit2.Response
 
 sealed class ApiResponse<out T : Any?> {
     data class Success<out T : Any?>(
@@ -15,3 +15,24 @@ sealed class ApiResponse<out T : Any?> {
     data object Failure : ApiResponse<Nothing>()
 }
 
+suspend fun <T> apiHandler(
+    apiResponse: suspend () -> Pair<Response<T>, ErrorResponse?>,
+): ApiResponse<T> {
+    runCatching {
+        val action = apiResponse.invoke()
+        val response = action.first
+        if (response.isSuccessful) {
+            response.body()?.let { body ->
+                return ApiResponse.Success(body)
+            }
+        } else {
+            return ApiResponse.Error(
+                errorCode = action.second?.statusCode ?: 0,
+                errorMessage = action.second?.message ?: "",
+            )
+        }
+    }.onFailure {
+        return ApiResponse.Error(errorMessage = it.message ?: "")
+    }
+    return ApiResponse.Failure
+}

--- a/app/src/main/java/com/mimo/android/data/model/response/ApiResponse.kt
+++ b/app/src/main/java/com/mimo/android/data/model/response/ApiResponse.kt
@@ -8,7 +8,7 @@ sealed class ApiResponse<out T : Any?> {
     ) : ApiResponse<T>()
 
     data class Error(
-        val errorCode: ErrorCode = ErrorCode.NONE,
+        val errorCode: Int = 0,
         val errorMessage: String = "",
     ) : ApiResponse<Nothing>()
 

--- a/app/src/main/java/com/mimo/android/data/model/response/ErrorResponse.kt
+++ b/app/src/main/java/com/mimo/android/data/model/response/ErrorResponse.kt
@@ -1,0 +1,6 @@
+package com.mimo.android.data.model.response
+
+data class ErrorResponse(
+    val statusCode: Int? = null,
+    val message: String? = null,
+)

--- a/app/src/main/java/com/mimo/android/data/model/response/UserSignUpResponse.kt
+++ b/app/src/main/java/com/mimo/android/data/model/response/UserSignUpResponse.kt
@@ -1,7 +1,5 @@
 package com.mimo.android.data.model.response
 
-import com.mimo.android.util.ErrorCode
-
 data class UserSignUpResponse(
     val data: Boolean? = null,
     val statusCode: String? = null,

--- a/app/src/main/java/com/mimo/android/data/model/response/UserSignUpResponse.kt
+++ b/app/src/main/java/com/mimo/android/data/model/response/UserSignUpResponse.kt
@@ -4,6 +4,6 @@ import com.mimo.android.util.ErrorCode
 
 data class UserSignUpResponse(
     val data: Boolean? = null,
-    val statusCode: ErrorCode? = null,
+    val statusCode: String? = null,
     val message: String? = null,
 )

--- a/app/src/main/java/com/mimo/android/data/network/login/NaverLoginManager.kt
+++ b/app/src/main/java/com/mimo/android/data/network/login/NaverLoginManager.kt
@@ -3,7 +3,6 @@ package com.mimo.android.data.network.login
 import android.content.Context
 import com.mimo.android.data.model.response.ApiResponse
 import com.mimo.android.data.model.response.LoginResponse
-import com.mimo.android.util.ErrorCode
 import com.navercorp.nid.NaverIdLoginSDK
 import com.navercorp.nid.oauth.NidOAuthLogin
 import com.navercorp.nid.oauth.OAuthLoginCallback
@@ -31,7 +30,7 @@ object NaverLoginManager {
 
         override fun onFailure(httpStatus: Int, message: String) {
             _loginResult.value = ApiResponse.Error(
-                errorCode = ErrorCode.FAILED_LOGIN,
+                errorCode = httpStatus,
                 errorMessage = message,
             )
         }
@@ -47,7 +46,7 @@ object NaverLoginManager {
 
         override fun onFailure(httpStatus: Int, message: String) {
             _loginResult.value = ApiResponse.Error(
-                errorCode = ErrorCode.FAILED_LOGIN,
+                errorCode = httpStatus,
                 errorMessage = message,
             )
         }

--- a/app/src/main/java/com/mimo/android/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/repositoryimpl/UserRepositoryImpl.kt
@@ -1,11 +1,13 @@
 package com.mimo.android.data.repositoryimpl
 
+import com.google.gson.Gson
 import com.mimo.android.data.datasource.remote.UserRemoteDataSource
-import com.mimo.android.data.repository.DataStoreRepository
-import com.mimo.android.data.repository.UserRepository
 import com.mimo.android.data.model.request.UserRequest
 import com.mimo.android.data.model.response.ApiResponse
-import com.mimo.android.util.ErrorCode
+import com.mimo.android.data.model.response.ErrorResponse
+import com.mimo.android.data.model.response.apiHandler
+import com.mimo.android.data.repository.DataStoreRepository
+import com.mimo.android.data.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -15,25 +17,28 @@ class UserRepositoryImpl @Inject constructor(
     private val dataStoreRepository: DataStoreRepository,
 ) : UserRepository {
     override fun signUp(userRequest: UserRequest): Flow<ApiResponse<Boolean>> = flow {
-        runCatching {
-            userRemoteDataSource.signUp(userRequest)
-        }.onSuccess { response ->
-            response.body()?.let {
-                it.data?.let {
-                    dataStoreRepository.saveAccessToken(userRequest.accessToken)
-                    dataStoreRepository.saveRefreshToken(userRequest.refreshToken)
-                    emit(ApiResponse.Success(data = it))
-                } ?: run {
-                    emit(
-                        ApiResponse.Error(
-                            errorCode = it.statusCode ?: ErrorCode.NONE,
-                            errorMessage = it.message ?: "",
-                        ),
-                    )
-                }
+        val response = apiHandler {
+            val result = userRemoteDataSource.signUp(userRequest)
+            val errorData = Gson().fromJson(result.errorBody()?.string(), ErrorResponse::class.java)
+            Pair(result, errorData)
+        }
+        when (response) {
+            is ApiResponse.Success -> {
+                dataStoreRepository.saveAccessToken(userRequest.accessToken)
+                dataStoreRepository.saveRefreshToken(userRequest.refreshToken)
+                emit(ApiResponse.Success(data = response.data.data ?: false))
             }
-        }.onFailure { // 다른 예외가 발생한 경우 -> 서버가 닫힌 경우
-            emit(ApiResponse.Error(errorMessage = it.message ?: ""))
+
+            is ApiResponse.Error -> {
+                emit(
+                    ApiResponse.Error(
+                        errorCode = response.errorCode,
+                        errorMessage = response.errorMessage,
+                    ),
+                )
+            }
+
+            else -> {}
         }
     }
 }

--- a/app/src/main/java/com/mimo/android/data/repositoryimpl/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/repositoryimpl/UserRepositoryImpl.kt
@@ -1,12 +1,12 @@
 package com.mimo.android.data.repositoryimpl
 
 import com.google.gson.Gson
+import com.mimo.android.data.datasource.local.LocalDataSource
 import com.mimo.android.data.datasource.remote.UserRemoteDataSource
 import com.mimo.android.data.model.request.UserRequest
 import com.mimo.android.data.model.response.ApiResponse
 import com.mimo.android.data.model.response.ErrorResponse
 import com.mimo.android.data.model.response.apiHandler
-import com.mimo.android.data.repository.DataStoreRepository
 import com.mimo.android.data.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
     private val userRemoteDataSource: UserRemoteDataSource,
-    private val dataStoreRepository: DataStoreRepository,
+    private val localDataSource: LocalDataSource,
 ) : UserRepository {
     override fun signUp(userRequest: UserRequest): Flow<ApiResponse<Boolean>> = flow {
         val response = apiHandler {
@@ -24,8 +24,8 @@ class UserRepositoryImpl @Inject constructor(
         }
         when (response) {
             is ApiResponse.Success -> {
-                dataStoreRepository.saveAccessToken(userRequest.accessToken)
-                dataStoreRepository.saveRefreshToken(userRequest.refreshToken)
+                localDataSource.saveAccessToken(userRequest.accessToken)
+                localDataSource.saveRefreshToken(userRequest.refreshToken)
                 emit(ApiResponse.Success(data = response.data.data ?: false))
             }
 

--- a/app/src/main/java/com/mimo/android/presentation/login/LoginEvent.kt
+++ b/app/src/main/java/com/mimo/android/presentation/login/LoginEvent.kt
@@ -1,7 +1,5 @@
 package com.mimo.android.presentation.login
 
-import com.mimo.android.util.ErrorCode
-
 
 sealed interface LoginEvent {
     data object Success : LoginEvent

--- a/app/src/main/java/com/mimo/android/presentation/login/LoginEvent.kt
+++ b/app/src/main/java/com/mimo/android/presentation/login/LoginEvent.kt
@@ -5,5 +5,5 @@ import com.mimo.android.util.ErrorCode
 
 sealed interface LoginEvent {
     data object Success : LoginEvent
-    data class Error(val errorCode: ErrorCode = ErrorCode.NONE, val errorMessage: String = "") : LoginEvent
+    data class Error(val errorCode: Int = 0, val errorMessage: String = "") : LoginEvent
 }

--- a/app/src/main/java/com/mimo/android/util/ErrorCode.kt
+++ b/app/src/main/java/com/mimo/android/util/ErrorCode.kt
@@ -1,5 +1,0 @@
-package com.mimo.android.util
-
-enum class ErrorCode {
-    INVALID_DATA_FORMAT, NONE, FAILED_LOGIN,
-}


### PR DESCRIPTION
## 관련 이슈
- #24 

## 작업 내용
- resposne로 들어오는 API 결과값을 일반적으로 처리하는 handler 구현
- 서버에서 들어오는 Error Instance와 일치하는 class 구현

- 실패 처리
![image](https://github.com/mini-moment/mimo-android/assets/99114456/e7a04e02-6757-4440-b432-28bd1497cfbe)
![image](https://github.com/mini-moment/mimo-android/assets/99114456/3de953b8-6e13-4123-bf43-cbeb1c6f4954)

- 성공 처리
![image](https://github.com/mini-moment/mimo-android/assets/99114456/8864e711-d99d-4dbf-95a9-56f361f1b1d6)


## 리뷰어에게 하고 싶은 말
- 반복적으로 레포지토리에서 response의 타입을 검증하는 로직이 있다고 생각했고, 이를 함수화 해서 해결하고 싶었던것이 후선 해당 PR의 목적입니다.
- 코드가 조금 어렵게 느껴질 수도 있다고 생각합니다. 하지만 에러 처리의 주도권이 안드로이드가 아닌 서버에서 하고싶었기 때문에 서버의 Custom Exception 구현은 필연적이라고 생각했습니다. 서버에서 내려주는 에러를 그대로 UI로 전송하는것이 클라이언트의 책임이라고 생각했기 때문입니다.
- 레트로핏 내부 코드로 인해 200 Ok가 아니라면 body가 null로 들어왔고, errorBody에 원래 채워지게 됩니다. 해당 errorBody를 객체로 변환시켜서 에러 핸들링 하는것에 성공했습니다.
  
## 참고 자료
https://mccoy-devloper.tistory.com/57