### PR TITLE
게시글 작성 구현

### DIFF
--- a/app/src/main/java/com/mimo/android/core/di/ApiModule.kt
+++ b/app/src/main/java/com/mimo/android/core/di/ApiModule.kt
@@ -1,7 +1,9 @@
 package com.mimo.android.core.di
 
+import com.mimo.android.data.network.api.PostApi
 import com.mimo.android.data.network.api.TagApi
 import com.mimo.android.data.network.api.UserApi
+import com.mimo.android.data.network.api.VideoApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,4 +26,16 @@ object ApiModule {
     fun provideTagApi(
         retrofit: Retrofit,
     ): TagApi = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun provideVideoApi(
+        retrofit: Retrofit,
+    ): VideoApi = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun providePostApi(
+        retrofit: Retrofit,
+    ): PostApi = retrofit.create()
 }

--- a/app/src/main/java/com/mimo/android/core/di/DataSourceModule.kt
+++ b/app/src/main/java/com/mimo/android/core/di/DataSourceModule.kt
@@ -42,4 +42,10 @@ interface DataSourceModule {
     fun provideVideoRemoteDataSource(
         videoRemoteDataSourceImpl: VideoRemoteDataSourceImpl,
     ): VideoRemoteDataSource
+
+    @Singleton
+    @Binds
+    fun providePostRemoteDataSource(
+        postRemoteDataSourceImpl: PostRemoteDataSourceImpl
+    ): PostRemoteDataSource
 }

--- a/app/src/main/java/com/mimo/android/core/di/DataSourceModule.kt
+++ b/app/src/main/java/com/mimo/android/core/di/DataSourceModule.kt
@@ -2,10 +2,14 @@ package com.mimo.android.core.di
 
 import com.mimo.android.data.datasource.local.LocalDataSource
 import com.mimo.android.data.datasource.local.LocalDataSourceImpl
+import com.mimo.android.data.datasource.remote.PostRemoteDataSource
+import com.mimo.android.data.datasource.remote.PostRemoteDataSourceImpl
 import com.mimo.android.data.datasource.remote.TagRemoteDataSource
 import com.mimo.android.data.datasource.remote.TagRemoteDataSourceImpl
 import com.mimo.android.data.datasource.remote.UserRemoteDataSource
 import com.mimo.android.data.datasource.remote.UserRemoteDataSourceImpl
+import com.mimo.android.data.datasource.remote.VideoRemoteDataSource
+import com.mimo.android.data.datasource.remote.VideoRemoteDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -32,4 +36,10 @@ interface DataSourceModule {
     fun provideTagRemoteDataSource(
         tagRemoteDataSourceImpl: TagRemoteDataSourceImpl,
     ): TagRemoteDataSource
+
+    @Singleton
+    @Binds
+    fun provideVideoRemoteDataSource(
+        videoRemoteDataSourceImpl: VideoRemoteDataSourceImpl,
+    ): VideoRemoteDataSource
 }

--- a/app/src/main/java/com/mimo/android/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/mimo/android/core/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.mimo.android.core.di
 
 import com.google.gson.GsonBuilder
+import com.mimo.android.data.network.AccessTokenInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -30,8 +31,11 @@ object NetworkModule {
 
     @Singleton
     @Provides
-    fun provideOkHttpClient() = OkHttpClient.Builder().run {
+    fun provideOkHttpClient(
+        accessTokenInterceptor: AccessTokenInterceptor,
+    ) = OkHttpClient.Builder().run {
         addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
+        addNetworkInterceptor(accessTokenInterceptor)
         connectTimeout(120, TimeUnit.SECONDS)
         readTimeout(120, TimeUnit.SECONDS)
         writeTimeout(120, TimeUnit.SECONDS)

--- a/app/src/main/java/com/mimo/android/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/mimo/android/core/di/RepositoryModule.kt
@@ -43,4 +43,10 @@ interface RepositoryModule {
     fun provideVideoRepository(
         videoRepositoryImpl: VideoRepositoryImpl,
     ): VideoRepository
+
+    @Singleton
+    @Binds
+    fun providePostRepository(
+        postRepositoryImpl: PostRepositoryImpl
+    ): PostRepository
 }

--- a/app/src/main/java/com/mimo/android/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/mimo/android/core/di/RepositoryModule.kt
@@ -1,11 +1,15 @@
 package com.mimo.android.core.di
 
 import com.mimo.android.data.repository.DataStoreRepository
+import com.mimo.android.data.repository.PostRepository
 import com.mimo.android.data.repository.TagRepository
 import com.mimo.android.data.repository.UserRepository
+import com.mimo.android.data.repository.VideoRepository
 import com.mimo.android.data.repositoryimpl.DataStoreRepositoryImpl
+import com.mimo.android.data.repositoryimpl.PostRepositoryImpl
 import com.mimo.android.data.repositoryimpl.TagRepositoryImpl
 import com.mimo.android.data.repositoryimpl.UserRepositoryImpl
+import com.mimo.android.data.repositoryimpl.VideoRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -33,4 +37,10 @@ interface RepositoryModule {
     fun provideTagRepository(
         tagRepositoryImpl: TagRepositoryImpl,
     ): TagRepository
+
+    @Singleton
+    @Binds
+    fun provideVideoRepository(
+        videoRepositoryImpl: VideoRepositoryImpl,
+    ): VideoRepository
 }

--- a/app/src/main/java/com/mimo/android/data/datasource/remote/PostRemoteDataSource.kt
+++ b/app/src/main/java/com/mimo/android/data/datasource/remote/PostRemoteDataSource.kt
@@ -1,0 +1,12 @@
+package com.mimo.android.data.datasource.remote
+
+import com.mimo.android.data.model.request.InsertPostRequest
+import com.mimo.android.data.model.response.InsertPostResponse
+import com.mimo.android.domain.model.TagData
+import retrofit2.Response
+
+interface PostRemoteDataSource {
+    suspend fun insertPost(
+        postRequest: InsertPostRequest,
+    ): Response<InsertPostResponse>
+}

--- a/app/src/main/java/com/mimo/android/data/datasource/remote/PostRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/datasource/remote/PostRemoteDataSourceImpl.kt
@@ -1,0 +1,17 @@
+package com.mimo.android.data.datasource.remote
+
+import com.mimo.android.data.model.request.InsertPostRequest
+import com.mimo.android.data.model.response.InsertPostResponse
+import com.mimo.android.data.network.api.PostApi
+import com.mimo.android.domain.model.TagData
+import retrofit2.Response
+import javax.inject.Inject
+
+class PostRemoteDataSourceImpl @Inject constructor(private val postApi: PostApi) :
+    PostRemoteDataSource {
+    override suspend fun insertPost(
+        postRequest: InsertPostRequest,
+    ): Response<InsertPostResponse> {
+        return postApi.insertPost(postRequest)
+    }
+}

--- a/app/src/main/java/com/mimo/android/data/datasource/remote/VideoRemoteDataSource.kt
+++ b/app/src/main/java/com/mimo/android/data/datasource/remote/VideoRemoteDataSource.kt
@@ -1,0 +1,10 @@
+package com.mimo.android.data.datasource.remote
+
+import com.mimo.android.data.model.response.UploadVideoResponse
+import okhttp3.MultipartBody
+import retrofit2.Response
+
+interface VideoRemoteDataSource {
+
+    suspend fun uploadVideo(file: MultipartBody.Part): Response<UploadVideoResponse>
+}

--- a/app/src/main/java/com/mimo/android/data/datasource/remote/VideoRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/datasource/remote/VideoRemoteDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package com.mimo.android.data.datasource.remote
+
+import com.mimo.android.data.model.response.UploadVideoResponse
+import com.mimo.android.data.network.api.VideoApi
+import okhttp3.MultipartBody
+import retrofit2.Response
+import javax.inject.Inject
+
+class VideoRemoteDataSourceImpl @Inject constructor(private val videoApi: VideoApi) :
+    VideoRemoteDataSource {
+    override suspend fun uploadVideo(file: MultipartBody.Part): Response<UploadVideoResponse> {
+        return videoApi.uploadVideo(file)
+    }
+}

--- a/app/src/main/java/com/mimo/android/data/model/request/InsertPostRequest.kt
+++ b/app/src/main/java/com/mimo/android/data/model/request/InsertPostRequest.kt
@@ -1,0 +1,13 @@
+package com.mimo.android.data.model.request
+
+import com.mimo.android.domain.model.TagData
+
+data class InsertPostRequest(
+    val title: String? = null,
+    val userId: Int? = null,
+    val videoUrl: String? = null,
+    val regionId: Int? = 0,
+    val latitude: Long? = 0L,
+    val longitude: Long? = 0L,
+    val tagList: List<TagData>? = emptyList(),
+)

--- a/app/src/main/java/com/mimo/android/data/model/response/InsertPostResponse.kt
+++ b/app/src/main/java/com/mimo/android/data/model/response/InsertPostResponse.kt
@@ -1,0 +1,5 @@
+package com.mimo.android.data.model.response
+
+data class InsertPostResponse(
+    val data: String? = null,
+)

--- a/app/src/main/java/com/mimo/android/data/model/response/UploadVideoResponse.kt
+++ b/app/src/main/java/com/mimo/android/data/model/response/UploadVideoResponse.kt
@@ -1,0 +1,5 @@
+package com.mimo.android.data.model.response
+
+data class UploadVideoResponse(
+    val data: String? = null,
+)

--- a/app/src/main/java/com/mimo/android/data/network/AccessTokenInterceptor.kt
+++ b/app/src/main/java/com/mimo/android/data/network/AccessTokenInterceptor.kt
@@ -1,0 +1,37 @@
+package com.mimo.android.data.network
+
+import com.mimo.android.data.model.response.ApiResponse
+import com.mimo.android.data.repository.DataStoreRepository
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AccessTokenInterceptor @Inject constructor(val dataStoreRepository: DataStoreRepository) :
+    Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val requestBuilder = originalRequest.newBuilder()
+        var accessToken: String? = runBlocking {
+            var token: String? = null
+            dataStoreRepository.getUserToken().collectLatest { response ->
+                when (response) {
+                    is ApiResponse.Success -> {
+                        token = response.data.accessToken
+                    }
+
+                    else -> {
+                        token = null
+                    }
+                }
+            }
+            token
+        }
+        val request =
+            requestBuilder.header(NetworkContract.Authorization, accessToken ?: "")
+                .build()
+        return chain.proceed(request)
+    }
+}

--- a/app/src/main/java/com/mimo/android/data/network/NetworkContract.kt
+++ b/app/src/main/java/com/mimo/android/data/network/NetworkContract.kt
@@ -1,0 +1,5 @@
+package com.mimo.android.data.network
+
+object NetworkContract {
+    const val Authorization = "Authorization"
+}

--- a/app/src/main/java/com/mimo/android/data/network/api/PostApi.kt
+++ b/app/src/main/java/com/mimo/android/data/network/api/PostApi.kt
@@ -1,0 +1,17 @@
+package com.mimo.android.data.network.api
+
+import com.mimo.android.data.model.request.InsertPostRequest
+import com.mimo.android.data.model.response.InsertPostResponse
+import com.mimo.android.domain.model.TagData
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface PostApi {
+
+    @POST("post/insert")
+    suspend fun insertPost(
+        @Body postRequest: InsertPostRequest,
+    ): Response<InsertPostResponse>
+}

--- a/app/src/main/java/com/mimo/android/data/network/api/VideoApi.kt
+++ b/app/src/main/java/com/mimo/android/data/network/api/VideoApi.kt
@@ -1,0 +1,17 @@
+package com.mimo.android.data.network.api
+
+import com.mimo.android.data.model.response.UploadVideoResponse
+import okhttp3.MultipartBody
+import retrofit2.Response
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface VideoApi {
+
+    @POST("video/upload")
+    @Multipart
+    suspend fun uploadVideo(
+        @Part video: MultipartBody.Part,
+    ): Response<UploadVideoResponse>
+}

--- a/app/src/main/java/com/mimo/android/data/repository/PostRepository.kt
+++ b/app/src/main/java/com/mimo/android/data/repository/PostRepository.kt
@@ -1,0 +1,12 @@
+package com.mimo.android.data.repository
+
+import com.mimo.android.data.model.request.InsertPostRequest
+import com.mimo.android.data.model.response.ApiResponse
+import kotlinx.coroutines.flow.Flow
+
+interface PostRepository {
+
+    suspend fun insertPost(
+        postRequest: InsertPostRequest,
+    ): Flow<ApiResponse<String>>
+}

--- a/app/src/main/java/com/mimo/android/data/repository/VideoRepository.kt
+++ b/app/src/main/java/com/mimo/android/data/repository/VideoRepository.kt
@@ -1,0 +1,10 @@
+package com.mimo.android.data.repository
+
+import com.mimo.android.data.model.response.ApiResponse
+import kotlinx.coroutines.flow.Flow
+import okhttp3.MultipartBody
+
+interface VideoRepository {
+
+    fun uploadVideo(file: MultipartBody.Part): Flow<ApiResponse<String>>
+}

--- a/app/src/main/java/com/mimo/android/data/repositoryimpl/DataStoreRepositoryImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/repositoryimpl/DataStoreRepositoryImpl.kt
@@ -4,7 +4,7 @@ import com.mimo.android.data.datasource.local.LocalDataSource
 import com.mimo.android.data.repository.DataStoreRepository
 import com.mimo.android.data.model.response.ApiResponse
 import com.mimo.android.data.model.response.LoginResponse
-import com.mimo.android.util.ErrorMessage
+import com.mimo.android.presentation.util.ErrorMessage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject

--- a/app/src/main/java/com/mimo/android/data/repositoryimpl/PostRepositoryImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/repositoryimpl/PostRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package com.mimo.android.data.repositoryimpl
+
+import com.google.gson.Gson
+import com.mimo.android.data.datasource.remote.PostRemoteDataSource
+import com.mimo.android.data.model.request.InsertPostRequest
+import com.mimo.android.data.model.response.ApiResponse
+import com.mimo.android.data.model.response.ErrorResponse
+import com.mimo.android.data.model.response.apiHandler
+import com.mimo.android.data.repository.PostRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class PostRepositoryImpl @Inject constructor(val postRemoteDataSource: PostRemoteDataSource) :
+    PostRepository {
+    override suspend fun insertPost(
+        postRequest: InsertPostRequest,
+    ): Flow<ApiResponse<String>> = flow {
+        val response = apiHandler {
+            val result = postRemoteDataSource.insertPost(postRequest)
+            val errorData = Gson().fromJson(result.errorBody()?.string(), ErrorResponse::class.java)
+            Pair(result, errorData)
+        }
+        when (response) {
+            is ApiResponse.Success -> {
+                emit(
+                    ApiResponse.Success(
+                        data = response.data.data ?: "",
+                    ),
+                )
+            }
+
+            is ApiResponse.Error -> {
+                emit(
+                    ApiResponse.Error(
+                        errorCode = response.errorCode,
+                        errorMessage = response.errorMessage,
+                    ),
+                )
+            }
+            else -> {}
+        }
+    }
+}

--- a/app/src/main/java/com/mimo/android/data/repositoryimpl/VideoRepositoryImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/repositoryimpl/VideoRepositoryImpl.kt
@@ -1,0 +1,39 @@
+package com.mimo.android.data.repositoryimpl
+
+import com.google.gson.Gson
+import com.mimo.android.data.datasource.remote.VideoRemoteDataSource
+import com.mimo.android.data.model.response.ApiResponse
+import com.mimo.android.data.model.response.ErrorResponse
+import com.mimo.android.data.model.response.apiHandler
+import com.mimo.android.data.repository.VideoRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import okhttp3.MultipartBody
+import javax.inject.Inject
+
+class VideoRepositoryImpl @Inject constructor(private val videoRemoteDataSource: VideoRemoteDataSource) :
+    VideoRepository {
+    override fun uploadVideo(file: MultipartBody.Part): Flow<ApiResponse<String>> = flow {
+        val response = apiHandler {
+            val result = videoRemoteDataSource.uploadVideo(file)
+            val errorData = Gson().fromJson(result.errorBody()?.string(), ErrorResponse::class.java)
+            Pair(result, errorData)
+        }
+        when (response) {
+            is ApiResponse.Success -> {
+                emit(ApiResponse.Success(data = response.data.data ?: ""))
+            }
+
+            is ApiResponse.Error -> {
+                emit(
+                    ApiResponse.Error(
+                        errorMessage = response.errorMessage,
+                        errorCode = response.errorCode,
+                    ),
+                )
+            }
+
+            else -> {}
+        }
+    }
+}

--- a/app/src/main/java/com/mimo/android/domain/model/PostData.kt
+++ b/app/src/main/java/com/mimo/android/domain/model/PostData.kt
@@ -1,0 +1,10 @@
+package com.mimo.android.domain.model
+
+data class PostData(
+    val title: String? = null,
+    val userId: Int? = null,
+    val videoUrl: String? = null,
+    val regionId: Int? = null,
+    val latitude: Long? = null,
+    val longitude: Long? = null,
+)

--- a/app/src/main/java/com/mimo/android/presentation/util/ErrorMessage.kt
+++ b/app/src/main/java/com/mimo/android/presentation/util/ErrorMessage.kt
@@ -4,4 +4,6 @@ object ErrorMessage {
     const val NO_ACCESS_TOKEN_MESSAGE = "No Access Token"
     const val NO_REFRESH_TOKEN_MESSAGE = "No Refresh Token"
     const val ENOUGH_HASH_TAG_MESSAGE = "해시태그는 최대 5개 지정 가능합니다."
+    const val NO_POST_VIDEO_URL = "영상을 선택해주세요."
+    const val NO_POST_TOPIC = "주제를 입력해주세요."
 }

--- a/app/src/main/java/com/mimo/android/presentation/util/ErrorMessage.kt
+++ b/app/src/main/java/com/mimo/android/presentation/util/ErrorMessage.kt
@@ -1,4 +1,4 @@
-package com.mimo.android.util
+package com.mimo.android.presentation.util
 
 object ErrorMessage {
     const val NO_ACCESS_TOKEN_MESSAGE = "No Access Token"

--- a/app/src/main/java/com/mimo/android/presentation/util/FileManager.kt
+++ b/app/src/main/java/com/mimo/android/presentation/util/FileManager.kt
@@ -1,0 +1,15 @@
+package com.mimo.android.presentation.util
+
+import android.content.Context
+import android.net.Uri
+import android.provider.MediaStore
+
+fun getRealPathFromURI(context: Context, contentUri: Uri): String {
+    val projection = arrayOf(MediaStore.Images.Media.DATA)
+    val cursor = context.contentResolver.query(contentUri, projection, null, null, null)
+    val columnIndex = cursor?.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
+    cursor?.moveToFirst()
+    val filePath = cursor?.getString(columnIndex!!)
+    cursor?.close()
+    return filePath!!
+}

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/ProgressRequestBody.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/ProgressRequestBody.kt
@@ -1,0 +1,41 @@
+package com.mimo.android.presentation.video.upload
+
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.BufferedSink
+import java.io.File
+import java.io.FileInputStream
+
+class ProgressRequestBody(
+    private val file: File,
+    private val contentType: MediaType?,
+    private val progressListener: ((Long, Long) -> Unit)?,
+) : RequestBody() {
+
+    override fun contentType(): MediaType? {
+        return contentType
+    }
+
+    override fun contentLength(): Long {
+        return file.length()
+    }
+
+    override fun writeTo(sink: BufferedSink) {
+        val fileLength = file.length()
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        val inputStream = FileInputStream(file)
+        var uploaded: Long = 0
+        inputStream.use { input ->
+            var read: Int
+            while (input.read(buffer).also { read = it } != -1) {
+                sink.write(buffer, 0, read)
+                uploaded += read
+                progressListener?.invoke(uploaded, fileLength)
+            }
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_BUFFER_SIZE = 2048
+    }
+}

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoFragment.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoFragment.kt
@@ -1,5 +1,7 @@
 package com.mimo.android.presentation.video.upload
 
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts.*
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -11,9 +13,13 @@ import com.mimo.android.R
 import com.mimo.android.databinding.FragmentUploadVideoBinding
 import com.mimo.android.domain.model.TagData
 import com.mimo.android.presentation.base.BaseFragment
+import com.mimo.android.presentation.util.getRealPathFromURI
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import java.io.File
 
 @AndroidEntryPoint
 class UploadVideoFragment :
@@ -21,11 +27,32 @@ class UploadVideoFragment :
 
     private val uploadVideoViewModel: UploadVideoViewModel by viewModels()
     private val tagListAdapter = TagListAdapter()
+    private val pickMedia =
+        registerForActivityResult(PickVisualMedia()) { uri ->
+            if (uri != null) {
+                val filePath = getRealPathFromURI(requireContext(), uri)
+                val file = File(filePath)
+                val videoRequestBody =
+                    ProgressRequestBody(file, "video/*".toMediaTypeOrNull()) { uploaded, total ->
+                        val progress = (uploaded.toFloat() / total.toFloat() * 100).toInt()
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            binding.progressUploadVideo.progress = progress
+                            binding.tvProgress.text = "$progress%"
+                        }
+                    }
+                val videoFile =
+                    MultipartBody.Part.createFormData("video", file.name, videoRequestBody)
+                uploadVideoViewModel.uploadVideo(videoFile)
+            }
+        }
 
     override fun initView() {
         with(binding) {
             btnFinishUpload.setOnClickListener {
-                requireActivity().finish()
+                uploadVideoViewModel.insertPost()
+            }
+            btnUploadVideo.setOnClickListener {
+                pickMedia.launch(PickVisualMediaRequest(PickVisualMedia.VideoOnly))
             }
             viewModel = uploadVideoViewModel
         }
@@ -55,6 +82,10 @@ class UploadVideoFragment :
                     when (uiEvent) {
                         is UploadVideoEvent.Error -> {
                             showMessage(uiEvent.errorMessage)
+                        }
+
+                        is UploadVideoEvent.Success -> {
+                            requireActivity().finish()
                         }
                     }
                 }

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoUiState.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoUiState.kt
@@ -3,8 +3,8 @@ package com.mimo.android.presentation.video.upload
 import com.mimo.android.domain.model.TagData
 
 data class UploadVideoUiState(
-    val videoUri: String? = "",
+    val videoUri: String? = null,
     val tags: List<TagData> = listOf(),
-    val topic: String? = "",
+    val topic: String? = null,
     val selectedTags: List<TagData> = listOf(),
 )

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
@@ -115,8 +115,33 @@ class UploadVideoViewModel @Inject constructor(
         }
     }
 
+    private suspend fun validationPost(): Boolean {
+        with(uiState.value) {
+            if (videoUri == null) {
+                _event.emit(
+                    UploadVideoEvent.Error(
+                        errorMessage = ErrorMessage.NO_POST_VIDEO_URL,
+                    ),
+                )
+                return false
+            }
+            if (topic == null) {
+                _event.emit(
+                    UploadVideoEvent.Error(
+                        errorMessage = ErrorMessage.NO_POST_TOPIC,
+                    ),
+                )
+                return false
+            }
+        }
+        return true
+    }
+
     fun insertPost() {
         viewModelScope.launch {
+            if (validationPost().not()) {
+                return@launch
+            }
             postRepository.insertPost(
                 postRequest = InsertPostRequest(
                     title = uiState.value.topic,

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
@@ -2,9 +2,12 @@ package com.mimo.android.presentation.video.upload
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.mimo.android.data.model.request.InsertPostRequest
 import com.mimo.android.data.model.response.ApiResponse
+import com.mimo.android.data.repository.PostRepository
 import com.mimo.android.data.repository.TagRepository
-import com.mimo.android.util.ErrorMessage
+import com.mimo.android.data.repository.VideoRepository
+import com.mimo.android.presentation.util.ErrorMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,11 +16,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import okhttp3.MultipartBody
 import javax.inject.Inject
 
 @HiltViewModel
 class UploadVideoViewModel @Inject constructor(
     private val tagRepository: TagRepository,
+    private val videoRepository: VideoRepository,
+    private val postRepository: PostRepository,
 ) : ViewModel() {
 
     private val _event = MutableSharedFlow<UploadVideoEvent>()
@@ -79,6 +85,75 @@ class UploadVideoViewModel @Inject constructor(
                     selectedTags = newSelectedTags,
                 )
             }
+        }
+    }
+
+    fun uploadVideo(file: MultipartBody.Part) {
+        viewModelScope.launch {
+            videoRepository.uploadVideo(file).collectLatest { response ->
+                when (response) {
+                    is ApiResponse.Success -> {
+                        _uiState.update { uiState ->
+                            uiState.copy(
+                                videoUri = response.data,
+                            )
+                        }
+                    }
+
+                    is ApiResponse.Error -> {
+                        _event.emit(
+                            UploadVideoEvent.Error(
+                                errorCode = response.errorCode,
+                                errorMessage = response.errorMessage,
+                            ),
+                        )
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+    }
+
+    fun insertPost() {
+        viewModelScope.launch {
+            postRepository.insertPost(
+                postRequest = InsertPostRequest(
+                    title = uiState.value.topic,
+                    videoUrl = uiState.value.videoUri,
+                    tagList = uiState.value.selectedTags,
+                ),
+            ).collectLatest { response ->
+                when (response) {
+                    is ApiResponse.Success -> {
+                        _uiState.update { uiState ->
+                            uiState.copy(
+                                videoUri = response.data,
+                            )
+                        }
+                        _event.emit(UploadVideoEvent.Success)
+                    }
+
+                    is ApiResponse.Error -> {
+                        _event.emit(
+                            UploadVideoEvent.Error(
+                                errorCode = response.errorCode,
+                                errorMessage = response.errorMessage,
+                            ),
+                        )
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+    }
+
+    fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+        _uiState.update { uiState ->
+            uiState.copy(
+                topic = s.toString(),
+            )
         }
     }
 }

--- a/app/src/main/res/layout/fragment_upload_video.xml
+++ b/app/src/main/res/layout/fragment_upload_video.xml
@@ -50,7 +50,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="30dp"
-            android:indeterminate="true"
             android:max="100"
             android:min="0"
             app:indicatorColor="@color/splash_background"
@@ -154,6 +153,7 @@
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/et_video_topic"
                 android:layout_width="match_parent"
+                android:onTextChanged="@{viewModel.onTextChanged}"
                 android:layout_height="match_parent" />
         </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
## 관련 이슈
- #37 
- #38 

## 작업 내용

### PhotoPicker 구현

![image](https://github.com/mini-moment/mimo-android/assets/99114456/6e961c3b-1f0b-4983-b287-250f273ac954)
- 권한 필요없이 갤러리에 접근할 수 있는 기능인데, 설명글은  노션에 있어용

### 동영상 업로드 Progressbar 구현

https://github.com/mini-moment/mimo-android/assets/99114456/f727289f-0e2e-46a3-8794-72e9fb6fd0df

![image](https://github.com/mini-moment/mimo-android/assets/99114456/097f48bc-5e42-4fb8-90bd-5138e61dcee1)
- 결과로는 서버 내 영상 경로에 해당하는 영상이름을 받아오는것을 확인했습니다.

### 게시글 작성 구현
- 영상과 주제를 선택하고 완료를 누른 후 게시글이 작성된것을 확인했습니다.
![image](https://github.com/mini-moment/mimo-android/assets/99114456/a05564e5-19c2-471f-b9ad-dde070ba8a9c)

- 영상을 올리지 않았거나, 주제를 입력하지 않은 경우에 대해 에러 메시지를 출력했습니다.
![](https://github.com/mini-moment/mimo-android/assets/99114456/ad0cef93-6c66-4130-a047-587955105275)![](https://github.com/mini-moment/mimo-android/assets/99114456/50398c11-5faf-4370-8fbd-497b726a280f)

## 리뷰어에게 하고 싶은 말
- 에러를 처리할 때 서버에서 데이터 검증을 할까, 안드로이드에서 할까 고민을 하다가 안드로이드에서 하는것이 맞다고 생각해서 코드를 작성했습니다.