### PR TITLE
Feat/cluster marker

### DIFF
--- a/app/src/main/java/com/mimo/android/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/mimo/android/core/di/NetworkModule.kt
@@ -21,7 +21,7 @@ object NetworkModule {
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         // val apiKey = "http://192.168.0.115:8080/"
         //val apiKey = "http://192.168.123.112:8080/"
-        val apiKey = "http://192.168.0.4:8080/"
+        val apiKey = "http://192.168.1.9:8080/"
         return Retrofit.Builder()
             .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
             .baseUrl(apiKey)

--- a/app/src/main/java/com/mimo/android/presentation/map/MapFragment.kt
+++ b/app/src/main/java/com/mimo/android/presentation/map/MapFragment.kt
@@ -153,17 +153,19 @@ class MapFragment : BaseMapFragment<FragmentMapBinding>(R.layout.fragment_map) {
                     putExtra("postIndex", markerList?.findMarkerIndex(it))
                 })
             },
-            clusterTag = {idList ->
-                val clusterList = mapViewModel.markerList.value?.filter{ idList.contains(it.id)} ?: emptyList()
-                Timber.d("확인이여 ${clusterList}")
+            clusterTag = { idList ->
+                val clusterList =
+                    mapViewModel.markerList.value?.filter { idList.contains(it.id) } ?: emptyList()
                 mapViewModel.setClusterMarkerList(clusterList)
             }
         )
     }
 
-    private fun observeClusterMarkerClick(){
-        mapViewModel.clusterMarkerList.observe(viewLifecycleOwner){
-            
+    private fun observeClusterMarkerClick() {
+        mapViewModel.clusterMarkerList.observe(viewLifecycleOwner) {
+            it.forEach {
+                Timber.d("클러스터링 클릭한 마커 정보 $it")
+            }
         }
     }
 

--- a/app/src/main/java/com/mimo/android/presentation/map/MapFragment.kt
+++ b/app/src/main/java/com/mimo/android/presentation/map/MapFragment.kt
@@ -147,13 +147,11 @@ class MapFragment : BaseMapFragment<FragmentMapBinding>(R.layout.fragment_map) {
     private fun clickMarkerEvent() { // 마커 클릭시
         clickMarker(markerBuilder,
             markerInfo = {
-                mapViewModel.markerList.value?.let { marker ->
-                    startActivity(Intent(requireActivity(), VideoDetailActivity::class.java).apply {
-                        putExtra("postList", marker.toTypedArray())
-                        putExtra("postIndex", marker.findMarkerIndex(it))
-                    })
-                }
-
+                val markerList = mapViewModel.markerList.value ?: emptyList()
+                startActivity(Intent(requireActivity(), VideoDetailActivity::class.java).apply {
+                    putExtra("postList", markerList.toTypedArray())
+                    putExtra("postIndex", markerList.findMarkerIndex(it))
+                })
             },
             clusterTag = { idList ->
                 val clusterList =

--- a/app/src/main/java/com/mimo/android/presentation/map/MapFragment.kt
+++ b/app/src/main/java/com/mimo/android/presentation/map/MapFragment.kt
@@ -11,12 +11,12 @@ import com.mimo.android.databinding.FragmentMapBinding
 import com.mimo.android.domain.model.MarkerData
 import com.mimo.android.domain.model.findMarkerIndex
 import com.mimo.android.presentation.base.BaseMapFragment
-import com.mimo.android.presentation.videodetail.VideoDetailActivity
 import com.mimo.android.presentation.util.checkLocationPermission
 import com.mimo.android.presentation.util.clickMarker
 import com.mimo.android.presentation.util.deleteMarker
 import com.mimo.android.presentation.util.makeMarker
 import com.mimo.android.presentation.util.requestMapPermission
+import com.mimo.android.presentation.videodetail.VideoDetailActivity
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.CameraUpdate
@@ -57,6 +57,7 @@ class MapFragment : BaseMapFragment<FragmentMapBinding>(R.layout.fragment_map) {
     }
 
     override fun iniViewCreated() {
+        observeClusterMarkerClick()
         clickLocationSearchBtn()
     }
 
@@ -110,8 +111,6 @@ class MapFragment : BaseMapFragment<FragmentMapBinding>(R.layout.fragment_map) {
                 }
                 val markers = makeMarker(it, markerBuilder)
 
-
-
                 mapViewModel.setCurrentMarkerList(markers)
                 markers.map = naverMap
             }
@@ -146,12 +145,25 @@ class MapFragment : BaseMapFragment<FragmentMapBinding>(R.layout.fragment_map) {
     }
 
     private fun clickMarkerEvent() { // 마커 클릭시
-        clickMarker(markerBuilder) {
-            val markerList = mapViewModel.markerList.value
-            startActivity(Intent(requireActivity(), VideoDetailActivity::class.java).apply {
-                putExtra("postList", markerList?.toTypedArray())
-                putExtra("postIndex", markerList?.findMarkerIndex(it))
-            })
+        clickMarker(markerBuilder,
+            markerInfo = {
+                val markerList = mapViewModel.markerList.value
+                startActivity(Intent(requireActivity(), VideoDetailActivity::class.java).apply {
+                    putExtra("postList", markerList?.toTypedArray())
+                    putExtra("postIndex", markerList?.findMarkerIndex(it))
+                })
+            },
+            clusterTag = {idList ->
+                val clusterList = mapViewModel.markerList.value?.filter{ idList.contains(it.id)} ?: emptyList()
+                Timber.d("확인이여 ${clusterList}")
+                mapViewModel.setClusterMarkerList(clusterList)
+            }
+        )
+    }
+
+    private fun observeClusterMarkerClick(){
+        mapViewModel.clusterMarkerList.observe(viewLifecycleOwner){
+            
         }
     }
 

--- a/app/src/main/java/com/mimo/android/presentation/map/MapFragment.kt
+++ b/app/src/main/java/com/mimo/android/presentation/map/MapFragment.kt
@@ -147,11 +147,13 @@ class MapFragment : BaseMapFragment<FragmentMapBinding>(R.layout.fragment_map) {
     private fun clickMarkerEvent() { // 마커 클릭시
         clickMarker(markerBuilder,
             markerInfo = {
-                val markerList = mapViewModel.markerList.value
-                startActivity(Intent(requireActivity(), VideoDetailActivity::class.java).apply {
-                    putExtra("postList", markerList?.toTypedArray())
-                    putExtra("postIndex", markerList?.findMarkerIndex(it))
-                })
+                mapViewModel.markerList.value?.let { marker ->
+                    startActivity(Intent(requireActivity(), VideoDetailActivity::class.java).apply {
+                        putExtra("postList", marker.toTypedArray())
+                        putExtra("postIndex", marker.findMarkerIndex(it))
+                    })
+                }
+
             },
             clusterTag = { idList ->
                 val clusterList =

--- a/app/src/main/java/com/mimo/android/presentation/map/MapViewModel.kt
+++ b/app/src/main/java/com/mimo/android/presentation/map/MapViewModel.kt
@@ -33,6 +33,13 @@ class MapViewModel @Inject constructor(
         _currentMarkerList.value = value
     }
 
+    private val _clusterMarkerList = MutableLiveData<List<MarkerData>>()
+    val clusterMarkerList : LiveData<List<MarkerData>> get() = _clusterMarkerList
+
+    fun setClusterMarkerList(value : List<MarkerData>){
+        _clusterMarkerList.value = value
+    }
+
 
     fun getMarkerList(latitude : Double, longitude : Double, radius : Double ){
         viewModelScope.launch {

--- a/app/src/main/java/com/mimo/android/presentation/util/MapUtil.kt
+++ b/app/src/main/java/com/mimo/android/presentation/util/MapUtil.kt
@@ -11,7 +11,6 @@ import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.Overlay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 suspend fun makeMarker(
     marker: List<MarkerData>,
@@ -37,7 +36,6 @@ suspend fun deleteMarker(marker: Clusterer<MarkerData>) {
     }
 }
 
-
 fun clickMarker(
     builder: Clusterer.ComplexBuilder<MarkerData>,
     markerInfo: (MarkerData) -> Unit?,
@@ -47,11 +45,9 @@ fun clickMarker(
 
         override fun updateClusterMarker(info: ClusterMarkerInfo, marker: Marker) {
             super.updateClusterMarker(info, marker)
-            Timber.d("클러스터 태그 안눌렀을 때 ${info.tag}")
             marker.onClickListener = Overlay.OnClickListener {
                 val idList = (info.tag as String).split(",").map { it.toInt() }
                 clusterTag(idList)
-                Timber.d("클러스터 태그 ${info.tag}")
                 false
             }
         }
@@ -66,10 +62,3 @@ fun clickMarker(
         }
     })
 }
-
-
-
-
-
-
-


### PR DESCRIPTION

## 관련 이슈
- #49 

## 작업 내용
<img width="389" alt="image" src="https://github.com/mini-moment/mimo-android/assets/71322949/bcc7dc3f-d1d7-42c7-8b40-f3b0517abd7b">


이미지에서 2개 클러스 된 마커를 클릭하면

<img width="752" alt="image" src="https://github.com/mini-moment/mimo-android/assets/71322949/99b0a247-f516-4eae-9cb5-54118bcfc785">

위와 같이 마커들 정보 나오는 것 확인했습니다!

## 리뷰어에게 하고 싶은 말
클러스터링 주변으로 화면 거리 계산해서 마커들 정보 가져와야 하나 계속 고민했었는데
complexBuilder에 tag로 클러스터링 하는게 있어서 이걸로 해결할 수 있었습니다!

클러스터링 할 때 tag를 만들어줄 수 있는데 이 부분에 마커들 id 값을 넣었고
이 만들어진 tag를 눌렀을 때 리스트로 변환하도록 해서 뺐습니다.
엄청 간단했는데 너무 오래걸렸네여...
  
## 참고 자료
https://navermaps.github.io/android-map-sdk/guide-ko/5-8.html
