### PR TITLE
동영상 편집 구현

### DIFF
--- a/app/src/main/java/com/mimo/android/presentation/util/ErrorMessage.kt
+++ b/app/src/main/java/com/mimo/android/presentation/util/ErrorMessage.kt
@@ -7,4 +7,5 @@ object ErrorMessage {
     const val NO_POST_VIDEO_URL = "영상을 선택해주세요."
     const val NO_POST_TOPIC = "주제를 입력해주세요."
     const val GET_THUMBNAILS_ERROR_MESSAGE = "썸네일을 불러오는데 실패했습니다."
+    const val FILE_SIZE_EXCEEDED_MESSAGE = "파일 용량이 초과되었습니다."
 }

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoEvent.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoEvent.kt
@@ -2,7 +2,7 @@ package com.mimo.android.presentation.video.upload
 
 interface UploadVideoEvent {
 
-    data object VideoUploadSuccess : UploadVideoEvent
+    data class VideoUploadSuccess(val videoPath: String) : UploadVideoEvent
     data object PostUploadSuccess : UploadVideoEvent
 
     data class ThumbnailsGetSuccess(val videoUrl: String) : UploadVideoEvent

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoFragment.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoFragment.kt
@@ -47,7 +47,7 @@ class UploadVideoFragment :
         if (uri != null) {
             val fileUrl = getRealPathFromURI(requireContext(), uri)
             val file = File(fileUrl)
-            uploadVideoViewModel.setVideo(uri.toString())
+            uploadVideoViewModel.setVideoUrl(uri.toString())
             val widthPixels = binding.recyclerViewVideoThumbnail.measuredWidth
             uploadVideoViewModel.getThumbnails(width = widthPixels, path = file.path)
         }

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoFragment.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoFragment.kt
@@ -1,6 +1,12 @@
 package com.mimo.android.presentation.video.upload
 
+import android.annotation.SuppressLint
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
 import android.net.Uri
+import android.os.Environment
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts.*
 import androidx.core.net.toUri
@@ -23,15 +29,18 @@ import com.mimo.android.presentation.dialog.LoadingDialog
 import com.mimo.android.presentation.util.converterTimeLine
 import com.mimo.android.presentation.util.getRealPathFromURI
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
+import java.nio.ByteBuffer
 
 @AndroidEntryPoint
 class UploadVideoFragment :
@@ -117,17 +126,76 @@ class UploadVideoFragment :
         if (uri.isNotEmpty()) {
             val filePath = getRealPathFromURI(requireContext(), uri.toUri())
             val file = File(filePath)
-            val requestBody: RequestBody = file.asRequestBody(
-                requireContext().getString(R.string.multipart_content_type)
-                    .toMediaTypeOrNull(),
-            )
-            val videoFile = MultipartBody.Part.createFormData(
-                requireContext().getString(R.string.multipart_value),
-                file.name,
-                requestBody,
-            )
-            uploadVideoViewModel.uploadVideo(videoFile)
+            val videoLength = player?.duration ?: 0
+            val newPosition1 = (videoLength * binding.sliderVideoThumbnail.values[0] / 100).toLong()
+            val newPosition2 = (videoLength * binding.sliderVideoThumbnail.values[1] / 100).toLong()
+            lifecycleScope.launch {
+                val editFile = withContext(Dispatchers.IO) {
+                    editVideo(file, newPosition1, newPosition2)
+                }
+                val requestBody: RequestBody = editFile.asRequestBody(
+                    requireContext().getString(R.string.multipart_content_type)
+                        .toMediaTypeOrNull(),
+                )
+                val videoFile = MultipartBody.Part.createFormData(
+                    requireContext().getString(R.string.multipart_value),
+                    editFile.name,
+                    requestBody,
+                )
+                uploadVideoViewModel.uploadVideo(videoFile)
+            }
         }
+    }
+
+    @SuppressLint("WrongConstant")
+    private fun editVideo(file: File, start: Long, end: Long): File {
+        val rootPath =
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+                .toString()
+        val tempFile = File(
+            "$rootPath/" + file.name.replace(
+                file.name,
+                "edit_${file.name}",
+            ),
+        )
+        val outputFilePath = tempFile.absolutePath
+        val extractor = MediaExtractor()
+        extractor.setDataSource(file.path)
+        val muxer = MediaMuxer(outputFilePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+        val trackIndexMap = IntArray(extractor.trackCount)
+        for (i in trackIndexMap.indices) {
+            val format = extractor.getTrackFormat(i)
+            val mime = format.getString(MediaFormat.KEY_MIME)
+            val trackIndex = muxer.addTrack(format)
+            trackIndexMap[i] = trackIndex
+        }
+        muxer.start()
+        val buffer = ByteBuffer.allocate(1024 * 1024)
+        val bufferInfo = MediaCodec.BufferInfo()
+        for (i in trackIndexMap.indices) {
+            extractor.selectTrack(i)
+            if (start != 0L) {
+                extractor.seekTo(start * 1000L, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+            }
+            while (true) {
+                bufferInfo.size = extractor.readSampleData(buffer, 0)
+                bufferInfo.presentationTimeUs = extractor.sampleTime
+                if (bufferInfo.size < 0) {
+                    break
+                }
+                if (bufferInfo.presentationTimeUs > end * 1000L) {
+                    break
+                }
+                bufferInfo.flags = extractor.sampleFlags
+                muxer.writeSampleData(trackIndexMap[i], buffer, bufferInfo)
+                extractor.advance()
+            }
+            extractor.unselectTrack(i)
+        }
+        extractor.release()
+        muxer.stop()
+        muxer.release()
+        return tempFile
     }
 
     private fun setRecyclerView() {
@@ -158,7 +226,7 @@ class UploadVideoFragment :
                         }
 
                         is UploadVideoEvent.VideoUploadSuccess -> {
-                            uploadVideoViewModel.insertPost()
+                            uploadVideoViewModel.insertPost(uiEvent.videoPath)
                         }
 
                         is UploadVideoEvent.PostUploadSuccess -> {

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
@@ -123,7 +123,7 @@ class UploadVideoViewModel @Inject constructor(
 
     fun uploadVideo(file: MultipartBody.Part) {
         viewModelScope.launch {
-리            if (file.body.contentLength() > maxFileSize) {
+            if (file.body.contentLength() > maxFileSize) {
                 _event.emit(
                     UploadVideoEvent.Error(
                         errorMessage = ErrorMessage.FILE_SIZE_EXCEEDED_MESSAGE,
@@ -181,7 +181,7 @@ class UploadVideoViewModel @Inject constructor(
         return true
     }
 
-    fun insertPost() {
+    fun insertPost(videoPath: String) {
         viewModelScope.launch {
             if (validationPost().not()) {
                 return@launch
@@ -189,7 +189,7 @@ class UploadVideoViewModel @Inject constructor(
             postRepository.insertPost(
                 postRequest = InsertPostRequest(
                     title = uiState.value.topic,
-                    videoUrl = uiState.value.videoUri,
+                    videoUrl = videoPath,
                     tagList = uiState.value.selectedTags,
                 ),
             ).collectLatest { response ->
@@ -197,7 +197,6 @@ class UploadVideoViewModel @Inject constructor(
                     is ApiResponse.Success -> {
                         _uiState.update { uiState ->
                             uiState.copy(
-                                videoUri = response.data,
                                 isLoading = LoadingUiState.Finish,
                             )
                         }

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
@@ -91,7 +91,7 @@ class UploadVideoViewModel @Inject constructor(
         }
     }
 
-    fun setVideo(uri: String) {
+    fun setVideoUrl(uri: String) {
         _uiState.update { state ->
             state.copy(
                 videoUri = uri,

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
@@ -123,6 +123,14 @@ class UploadVideoViewModel @Inject constructor(
 
     fun uploadVideo(file: MultipartBody.Part) {
         viewModelScope.launch {
+리            if (file.body.contentLength() > maxFileSize) {
+                _event.emit(
+                    UploadVideoEvent.Error(
+                        errorMessage = ErrorMessage.FILE_SIZE_EXCEEDED_MESSAGE,
+                    ),
+                )
+                return@launch
+            }
             _uiState.update { uiState ->
                 uiState.copy(
                     isLoading = LoadingUiState.Loading,
@@ -132,7 +140,7 @@ class UploadVideoViewModel @Inject constructor(
                 when (response) {
                     is ApiResponse.Success -> {
                         _event.emit(
-                            UploadVideoEvent.VideoUploadSuccess,
+                            UploadVideoEvent.VideoUploadSuccess(response.data),
                         )
                     }
 
@@ -222,5 +230,9 @@ class UploadVideoViewModel @Inject constructor(
                 topic = s.toString(),
             )
         }
+    }
+
+    companion object {
+        const val maxFileSize = 60 * 1024 * 1024
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #55 

## 작업 내용

###  동영상 편집 구현
#### 원본 영상
https://github.com/mini-moment/mimo-android/assets/99114456/2c0afbc3-b39c-45f3-87bf-3c93278408f5

#### 편집 기능 
https://github.com/mini-moment/mimo-android/assets/99114456/01bb86e2-6435-4ac0-9362-b2a230fdfb4f

#### 편집 영상
https://github.com/mini-moment/mimo-android/assets/99114456/c8dff331-3b68-449c-a9d3-26ed5ca4c50e

#### 에러 처리
https://github.com/mini-moment/mimo-android/assets/99114456/ece66700-daf0-47e3-85f5-8f960b200528

## 리뷰어에게 하고 싶은 말
- 영상 크기가 너무 크면 httpLogingLevel에서 터져버리더라고요.. 그래서 개발 단계에선 로깅 레벨을 단순화 할 수도 없고, 영상 크기가 너무 크면 업로드도 오래걸려서 일단 영상 크기 제한을 줬는데, 개선 방향으론 chunk로 쪼개서 전달하고싶어요
- 편집한 영상에 대해 무조건 가로로 재생이 되더라고요, 이 부분 조금 고쳐야할것같은데 다음 PR에서 개선해볼게요  
## 참고 자료
https://velog.io/@windsekirun/Android-MediaCodec-MediaMuxer-%EC%82%B4%ED%8E%B4%EB%B3%B4%EA%B8%B0