### PR TITLE
유저 프로필 이미지 불러오기

### DIFF
--- a/app/src/main/java/com/mimo/android/data/model/request/UserRequest.kt
+++ b/app/src/main/java/com/mimo/android/data/model/request/UserRequest.kt
@@ -3,6 +3,7 @@ package com.mimo.android.data.model.request
 data class UserRequest(
     val userName: String = "",
     val userContact: String? = null,
+    val profileImageUrl: String = "",
     val accessToken: String = "",
     val refreshToken: String = "",
 )

--- a/app/src/main/java/com/mimo/android/data/model/response/LoginResponse.kt
+++ b/app/src/main/java/com/mimo/android/data/model/response/LoginResponse.kt
@@ -3,6 +3,7 @@ package com.mimo.android.data.model.response
 data class LoginResponse(
     val userName: String? = null,
     val userContact: String? = null,
+    val profileImageUrl: String? = null,
     val accessToken: String? = null,
     val refreshToken: String? = null,
 )

--- a/app/src/main/java/com/mimo/android/data/network/login/NaverLoginManager.kt
+++ b/app/src/main/java/com/mimo/android/data/network/login/NaverLoginManager.kt
@@ -22,6 +22,7 @@ object NaverLoginManager {
                 LoginResponse(
                     userName = response.profile?.name ?: "",
                     userContact = response.profile?.mobile ?: "",
+                    profileImageUrl = response.profile?.profileImage ?: "",
                     accessToken = NaverIdLoginSDK.getAccessToken() ?: "",
                     refreshToken = NaverIdLoginSDK.getRefreshToken() ?: "",
                 ),

--- a/app/src/main/java/com/mimo/android/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/mimo/android/presentation/login/LoginViewModel.kt
@@ -55,6 +55,7 @@ class LoginViewModel @Inject constructor(
                 userName = loginResponse.userName ?: "",
                 userContact = loginResponse.userContact ?: "",
                 accessToken = loginResponse.accessToken ?: "",
+                profileImageUrl = loginResponse.profileImageUrl ?: "",
                 refreshToken = loginResponse.refreshToken ?: "",
             ),
         ).collectLatest { signUpResponse ->


### PR DESCRIPTION
## 관련 이슈
- #58 

## 작업 내용
#### 유저 프로필 이미지 불러오기
<img width="1117" alt="image" src="https://github.com/mini-moment/mimo-android/assets/99114456/c03777a1-1302-4639-b825-848352fb2e5b">

<img width="1080" alt="image" src="https://github.com/mini-moment/mimo-android/assets/99114456/57ca168d-a502-4759-aea4-8c5ddf055e1a">

- 저장된 url로 가면 프로필 이미지 있는거 확인했습니다

## 리뷰어에게 하고 싶은 말
- 초기 네이버 로그인 설정에서 프로필 이미지 정보 동의를 하지 않아서, 현재 오류가 생길 수도 있어서 네이버 로그인 연동 해제하고 재로그인 시도하면 프로필 이미지가 정상적으로 받아와집니당  
