### PR TITLE
멀티파트 처리 코드 분리

### DIFF
--- a/app/src/main/java/com/mimo/android/data/repository/PostRepository.kt
+++ b/app/src/main/java/com/mimo/android/data/repository/PostRepository.kt
@@ -1,14 +1,14 @@
 package com.mimo.android.data.repository
 
+import com.mimo.android.data.model.request.InsertPostRequest
 import com.mimo.android.data.model.response.ApiResponse
 import kotlinx.coroutines.flow.Flow
-import okhttp3.MultipartBody
-import okhttp3.RequestBody
+import java.io.File
 
 interface PostRepository {
 
     suspend fun insertPost(
-        postRequest: RequestBody,
-        thumbnail: MultipartBody.Part,
+        postRequest: InsertPostRequest,
+        thumbnail: File,
     ): Flow<ApiResponse<String>>
 }

--- a/app/src/main/java/com/mimo/android/data/repository/VideoRepository.kt
+++ b/app/src/main/java/com/mimo/android/data/repository/VideoRepository.kt
@@ -2,9 +2,8 @@ package com.mimo.android.data.repository
 
 import com.mimo.android.data.model.response.ApiResponse
 import kotlinx.coroutines.flow.Flow
-import okhttp3.MultipartBody
+import java.io.File
 
 interface VideoRepository {
-
-    fun uploadVideo(file: MultipartBody.Part): Flow<ApiResponse<String>>
+    fun uploadVideo(file: File): Flow<ApiResponse<String>>
 }

--- a/app/src/main/java/com/mimo/android/data/repositoryimpl/PostRepositoryImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/repositoryimpl/PostRepositoryImpl.kt
@@ -2,24 +2,32 @@ package com.mimo.android.data.repositoryimpl
 
 import com.google.gson.Gson
 import com.mimo.android.data.datasource.remote.PostRemoteDataSource
+import com.mimo.android.data.model.request.InsertPostRequest
 import com.mimo.android.data.model.response.ApiResponse
 import com.mimo.android.data.model.response.ErrorResponse
 import com.mimo.android.data.model.response.apiHandler
 import com.mimo.android.data.repository.PostRepository
+import com.mimo.android.data.util.MultiPartUtil
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import okhttp3.MultipartBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.File
 import javax.inject.Inject
 
-class PostRepositoryImpl @Inject constructor(val postRemoteDataSource: PostRemoteDataSource) :
+class PostRepositoryImpl @Inject constructor(private val postRemoteDataSource: PostRemoteDataSource) :
     PostRepository {
+
     override suspend fun insertPost(
-        postRequest: RequestBody,
-        thumbnail: MultipartBody.Part,
+        postRequest: InsertPostRequest,
+        thumbnail: File,
     ): Flow<ApiResponse<String>> = flow {
+        val data = MultiPartUtil.convertToImage(thumbnail)
+        val requestBody: RequestBody = Gson().toJson(postRequest)
+            .toRequestBody("application/json".toMediaTypeOrNull())
         val response = apiHandler {
-            val result = postRemoteDataSource.insertPost(postRequest, thumbnail)
+            val result = postRemoteDataSource.insertPost(requestBody, data)
             val errorData = Gson().fromJson(result.errorBody()?.string(), ErrorResponse::class.java)
             Pair(result, errorData)
         }

--- a/app/src/main/java/com/mimo/android/data/repositoryimpl/VideoRepositoryImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/repositoryimpl/VideoRepositoryImpl.kt
@@ -6,16 +6,23 @@ import com.mimo.android.data.model.response.ApiResponse
 import com.mimo.android.data.model.response.ErrorResponse
 import com.mimo.android.data.model.response.apiHandler
 import com.mimo.android.data.repository.VideoRepository
+import com.mimo.android.data.util.MultiPartUtil
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import okhttp3.MultipartBody
+import java.io.File
 import javax.inject.Inject
 
 class VideoRepositoryImpl @Inject constructor(private val videoRemoteDataSource: VideoRemoteDataSource) :
     VideoRepository {
-    override fun uploadVideo(file: MultipartBody.Part): Flow<ApiResponse<String>> = flow {
+
+    override fun uploadVideo(file: File): Flow<ApiResponse<String>> = flow {
+        val videoFile = MultiPartUtil.convertToVideo(file)
+        if (videoFile.body.contentLength() > MultiPartUtil.MAX_FILE_SIZE) {
+            emit(ApiResponse.Failure)
+            return@flow
+        }
         val response = apiHandler {
-            val result = videoRemoteDataSource.uploadVideo(file)
+            val result = videoRemoteDataSource.uploadVideo(videoFile)
             val errorData = Gson().fromJson(result.errorBody()?.string(), ErrorResponse::class.java)
             Pair(result, errorData)
         }

--- a/app/src/main/java/com/mimo/android/data/util/MultiPartUtil.kt
+++ b/app/src/main/java/com/mimo/android/data/util/MultiPartUtil.kt
@@ -1,0 +1,39 @@
+package com.mimo.android.data.util
+
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+
+object MultiPartUtil {
+    private const val VIDEO_CONTENT_TYPE = "video/*"
+    private const val VIDEO_VALUE = "video"
+    private const val IMAGE_CONTENT_TYPE = "image/jpeg"
+    private const val IMAGE_VALUE = "thumbnail"
+    const val MAX_FILE_SIZE = 60 * 1024 * 1024
+
+    fun convertToVideo(video: File): MultipartBody.Part {
+        val requestBody: RequestBody = video.asRequestBody(
+            VIDEO_CONTENT_TYPE
+                .toMediaTypeOrNull(),
+        )
+        return MultipartBody.Part.createFormData(
+            VIDEO_VALUE,
+            video.name,
+            requestBody,
+        )
+    }
+
+    fun convertToImage(thumbnail: File): MultipartBody.Part {
+        val requestBody = thumbnail.asRequestBody(
+            IMAGE_CONTENT_TYPE
+                .toMediaTypeOrNull(),
+        )
+        return MultipartBody.Part.createFormData(
+            IMAGE_VALUE,
+            thumbnail.name,
+            requestBody,
+        )
+    }
+}

--- a/app/src/main/java/com/mimo/android/presentation/util/FileManager.kt
+++ b/app/src/main/java/com/mimo/android/presentation/util/FileManager.kt
@@ -19,7 +19,7 @@ fun getRealPathFromURI(context: Context, contentUri: Uri): String {
     return filePath!!
 }
 
-fun convertBitmapToFile(context : Context,bitmap: Bitmap): File {
+fun convertBitmapToFile(context: Context, bitmap: Bitmap): File {
     val rootPath =
         context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
             .toString()

--- a/app/src/main/res/values/string-video.xml
+++ b/app/src/main/res/values/string-video.xml
@@ -2,6 +2,4 @@
 <resources>
     <string name="hash_tag_title">해시태그</string>
     <string name="video_topic_title">주제</string>
-    <string name="multipart_content_type">video/*</string>
-    <string name="multipart_value">video</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- #65 

## 작업 내용

저번 코드 리뷰 받은것처럼 gson이나 멀티파트를 처리하는 로직이 UI에 있는것을 개선해봤습니다.
멀티파트로 바꾸는 파일은 영상이랑 이미지가 있는데, 이를 MultiPartUtil에 함수로 처리하도록 했습니다.
그 외 Gson으로 바꾸는 코드는 레포지토리에서 직접 처리하는것으로 했구요.
코드 바꾸고 실행을 해본 결과 정상적으로 동작하는것을 확인했습니다.


## 리뷰어에게 하고 싶은 말
- 저번 리뷰에서 해당 분리가 나중 계층 분리 함에 있어서 필요하다고 이해를 했습니다. 그리고 UI에서 데이터를 MultiPart 혹은 gson으로 바꾸는것보단 다른 계층에서 하는것이 맞다고 이해를 했는데 맞을까용??
  
