### PR TITLE
게시글 위치 정보 추가

### DIFF
--- a/app/src/main/java/com/mimo/android/data/datasource/remote/PostRemoteDataSource.kt
+++ b/app/src/main/java/com/mimo/android/data/datasource/remote/PostRemoteDataSource.kt
@@ -9,5 +9,7 @@ interface PostRemoteDataSource {
     suspend fun insertPost(
         postRequest: RequestBody,
         thumbnail: MultipartBody.Part,
+        latitude: Double,
+        longitude: Double,
     ): Response<InsertPostResponse>
 }

--- a/app/src/main/java/com/mimo/android/data/datasource/remote/PostRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/datasource/remote/PostRemoteDataSourceImpl.kt
@@ -12,7 +12,9 @@ class PostRemoteDataSourceImpl @Inject constructor(private val postApi: PostApi)
     override suspend fun insertPost(
         postRequest: RequestBody,
         thumbnail: MultipartBody.Part,
+        latitude: Double,
+        longitude: Double,
     ): Response<InsertPostResponse> {
-        return postApi.insertPost(postRequest, thumbnail)
+        return postApi.insertPost(postRequest, thumbnail, latitude, longitude)
     }
 }

--- a/app/src/main/java/com/mimo/android/data/model/request/InsertPostRequest.kt
+++ b/app/src/main/java/com/mimo/android/data/model/request/InsertPostRequest.kt
@@ -6,8 +6,5 @@ data class InsertPostRequest(
     val title: String? = null,
     val userId: Int? = null,
     val videoUrl: String? = null,
-    val regionId: Int? = 0,
-    val latitude: Long? = 0L,
-    val longitude: Long? = 0L,
     val tagList: List<TagData>? = emptyList(),
 )

--- a/app/src/main/java/com/mimo/android/data/network/api/PostApi.kt
+++ b/app/src/main/java/com/mimo/android/data/network/api/PostApi.kt
@@ -15,5 +15,7 @@ interface PostApi {
     suspend fun insertPost(
         @Part("post") post: RequestBody,
         @Part thumbnail: MultipartBody.Part,
+        @Part("latitude") latitude: Double,
+        @Part("longitude") longitude: Double,
     ): Response<InsertPostResponse>
 }

--- a/app/src/main/java/com/mimo/android/data/repository/PostRepository.kt
+++ b/app/src/main/java/com/mimo/android/data/repository/PostRepository.kt
@@ -10,5 +10,7 @@ interface PostRepository {
     suspend fun insertPost(
         postRequest: InsertPostRequest,
         thumbnail: File,
+        latitude: Double,
+        longitude: Double,
     ): Flow<ApiResponse<String>>
 }

--- a/app/src/main/java/com/mimo/android/data/repositoryimpl/PostRepositoryImpl.kt
+++ b/app/src/main/java/com/mimo/android/data/repositoryimpl/PostRepositoryImpl.kt
@@ -22,12 +22,14 @@ class PostRepositoryImpl @Inject constructor(private val postRemoteDataSource: P
     override suspend fun insertPost(
         postRequest: InsertPostRequest,
         thumbnail: File,
+        latitude: Double,
+        longitude: Double,
     ): Flow<ApiResponse<String>> = flow {
         val data = MultiPartUtil.convertToImage(thumbnail)
         val requestBody: RequestBody = Gson().toJson(postRequest)
             .toRequestBody("application/json".toMediaTypeOrNull())
         val response = apiHandler {
-            val result = postRemoteDataSource.insertPost(requestBody, data)
+            val result = postRemoteDataSource.insertPost(requestBody, data, latitude, longitude)
             val errorData = Gson().fromJson(result.errorBody()?.string(), ErrorResponse::class.java)
             Pair(result, errorData)
         }

--- a/app/src/main/java/com/mimo/android/presentation/util/ErrorMessage.kt
+++ b/app/src/main/java/com/mimo/android/presentation/util/ErrorMessage.kt
@@ -8,4 +8,5 @@ object ErrorMessage {
     const val NO_POST_TOPIC = "주제를 입력해주세요."
     const val GET_THUMBNAILS_ERROR_MESSAGE = "썸네일을 불러오는데 실패했습니다."
     const val FILE_SIZE_EXCEEDED_MESSAGE = "파일 용량이 초과되었습니다."
+    const val GPS_ERROR_MESSAGE = "위치정보를 불러오는데 실패했습니다."
 }

--- a/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
+++ b/app/src/main/java/com/mimo/android/presentation/video/upload/UploadVideoViewModel.kt
@@ -184,7 +184,12 @@ class UploadVideoViewModel @Inject constructor(
         return true
     }
 
-    fun insertPost(postRequest: InsertPostRequest, thumbnail: File) {
+    fun insertPost(
+        postRequest: InsertPostRequest,
+        thumbnail: File,
+        latitude: Double,
+        longitude: Double,
+    ) {
         viewModelScope.launch {
             if (validationPost().not()) {
                 return@launch
@@ -192,6 +197,8 @@ class UploadVideoViewModel @Inject constructor(
             postRepository.insertPost(
                 postRequest = postRequest,
                 thumbnail = thumbnail,
+                latitude,
+                longitude,
             ).collectLatest { response ->
                 when (response) {
                     is ApiResponse.Success -> {


### PR DESCRIPTION
## 관련 이슈
- #69 

## 작업 내용
### 게시글 등록 API 수정 및 게시글 위치 지정
그 전 게시글 위치 정보를 저장하지 않았었습니다.
서버 코드를 변경하고, 게시글을 등록할때 유저의 위치 정보를 서버로 보내서 마커 형태로 저장하도록 수정했습니다.
결과 현재 위치에서 게시글을 등록할 경우 마커가 생성되고, 클러스터링까지 되는걸로 확인했숩니다.
![image](https://github.com/mini-moment/mimo-android/assets/99114456/5955e9f3-5cad-4e35-85b3-55c30288e51c)

## 리뷰어에게 하고싶은말
위치를 등록할때 현재 위치 기반으로 게시글을 올리도록 했는데, 다른 위치에서 올리고 싶어질 때를 생각해야 할 것 같아요
영상 업로드에 대한 트리거를 지도 누르고 -> 지도 위치 받아와서 전달 -> 영상 업로드 이렇게 해야할지 고민해야할것같숩니다
## 참고 자료
https://tekken5953.tistory.com/17
